### PR TITLE
Fix for path resolution.  Add options for including specific extensions.  Add some documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@
   For a main.js
 
 ```javascript
-var rfolder = require('rfolder');
 var contents = rfolder('./misc');
-console.log(contents['robot.html']);
+console.log(contents['robot'].hello());
 ```
 
-  And a misc/robot.html
+  And a misc/robot.js file.
 
-```html
-<b>beep boop</b>
+```javascript
+exports.hello = function() {
+    return("Beep boop");
+}
 ```
 
   first `npm install rfolderify` into your project, then:
@@ -42,6 +43,28 @@ b.transform('rfolderify');
 
 b.bundle().pipe(fs.createWriteStream('bundle.js'));
 ```
+
+## More options
+
+You can pass an `options` parameter to rfolder:
+
+```javascript
+var contents = rfolder('./misc', {extensions: [".coffee", ".jade"], keepExt: [".jade"]});
+```
+
+Valid options are:
+
+* `extensions` - A list of extensions to require.  If this is not provided, the default is to
+  require any file which node.js would require. e.g. `[".js", ".coffee", ".jade"]` to require all
+  .js, .coffee, and .jade files from the directory.
+* `checkExt` - If false, then `extensions` will be ignored, and all files will be required
+  regardless of their extension.
+* `keepExt` - By default, rfolder strips extensions from file names when generating keys for the
+  folder object.  `keepExt` can be set `true` to keep all extensions, or to an array of extensions
+  to keep.  For example, if you have a folder containing a "robot.js" and a "robot.jade", then
+  passing `{keepExt: '.jade'}` would make it so `contents['robot']` would refer to the .coffee file,
+  while `contents['robot.jade']` would refer to the jade file.
+* `require` - JS string used to require each file.  Defaults to "require".
 
 ## Direct Usage
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var falafel = require('falafel');
 
 var defaults = {require:"require",}
 
-module.exports = function (file, options) {
+module.exports = function (file) {
     if (/\.json$/.test(file)) return through();
 
     var data = '';
@@ -38,16 +38,27 @@ module.exports = function (file, options) {
         var output = falafel(data, function (node) {
             if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name === 'rfolder') {
                 ++pending;
+
+                // Parse arguemnts to calls to `require(module, options)`
                 var args = node.arguments;
                 for (var i = 0; i < args.length; i++) {
                     var t = 'return ' + (args[i]).source();
                     args[i] = Function(varNames, t).apply(null, vars);
                 }
-                args[1] = args[1] || {};
-                args[1].require = args[1].require || "require";
-                args[1].checkExt = args[1].checkExt != null ? args[1].checkExt : true;
 
-                listRequireables(args[0],args[1].checkExt,function(err,files) {
+                // Resolve the foler to require relative the file which is requiring it
+                var parentDir = path.dirname(file);
+                var folder = path.resolve(parentDir, args[0])
+
+                var options = args[1] || {}
+                options.require = args[1].require || "require";
+                options.checkExt = args[1].checkExt != null ? args[1].checkExt : true;
+                options.keepExt = args[1].keepExt || false;
+                // By default, require anything that node.js would require
+                options.extensions = args[1].extensions || Object.keys(require.extensions);
+
+
+                listRequireables(folder, options, function(err,files) {
                     if(err) return tr.emit('error',err);
                     var obj = '{';
                     for(var p in files) if(({}).hasOwnProperty.call(files,p)) {
@@ -64,17 +75,23 @@ module.exports = function (file, options) {
     }
 };
 
-function listRequireables(dir,check,cb) {
+function listRequireables(dir,options,cb) {
     fs.readdir(dir,function(err,files) {
         if(err) return cb(err);
-        var results = {}, file, base, full, ext;
+        var results = {}, file, base, full, ext, symbol, shouldRequire, keepExt;
         for(var i = 0, l = files.length; i < l; ++i) {
             file = files[i];
             ext = path.extname(file);
-            if(!check || ext in require.extensions) { // yup, this works with (coffee|live)ify
-                base = path.basename(file,ext);
+
+            shouldRequire = !options.checkExt ||
+                (options.extensions.indexOf(ext) != -1);
+
+            if(shouldRequire) {
+                keepExt = (options.keepExt === true) ||
+                    (options.keepExt && options.keepExt.indexOf(ext) != -1)
+                symbol = keepExt ? file : path.basename(file,ext);
                 full = path.resolve(dir,file);
-                results[base] = full;
+                results[symbol] = full;
             }
         }
         cb(null,results);

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (file) {
 
     var tr = through(write, end);
     return tr;
-    
+
     function write (buf) { data += buf }
     function end () {
         try {
@@ -50,19 +50,21 @@ module.exports = function (file) {
                 var parentDir = path.dirname(file);
                 var folder = path.resolve(parentDir, args[0])
 
-                var options = args[1] || {}
-                options.require = args[1].require || "require";
-                options.checkExt = args[1].checkExt != null ? args[1].checkExt : true;
-                options.keepExt = args[1].keepExt || false;
+                var options = args[1] || {};
+                options.require = options.require || "require";
+                options.checkExt = options.checkExt != null ? options.checkExt : true;
+                options.keepExt = options.keepExt || false;
                 // By default, require anything that node.js would require
-                options.extensions = args[1].extensions || Object.keys(require.extensions);
+                options.extensions = options.extensions || Object.keys(require.extensions);
 
 
                 listRequireables(folder, options, function(err,files) {
                     if(err) return tr.emit('error',err);
                     var obj = '{';
                     for(var p in files) if(({}).hasOwnProperty.call(files,p)) {
-                        obj += JSON.stringify(p)+': '+args[1].require+'('+JSON.stringify(files[p])+'),';
+                        // Turn absolute paths back into relative paths.
+                        relativePath = './' + path.relative(parentDir, files[p])
+                        obj += JSON.stringify(p)+': '+options.require+'('+JSON.stringify(relativePath)+'),';
                     }
                     obj = obj.substr(0,obj.length-1); //remove trailing comma
                     obj += '}';


### PR DESCRIPTION
- Resolve path names of 'rfolder'ed files relative to the file which 'rfolder's them.  Handy when you're running browserify from a different directory than your source.
- Allow user to override the list of extensions that will be required via 'options.extensions'.
- Allow selective keeping of extensions via 'options.keepExt'.
